### PR TITLE
Delete duplicate definition of SaaS

### DIFF
--- a/cloud-saas/readme.md
+++ b/cloud-saas/readme.md
@@ -124,13 +124,6 @@ Click on the letter to go to the term:
   <dd>A service that manages storage, servers, and networking resources for businesses through virtual machines. One of three main services, the other two are SaaS and PaaS.</dd>
 </dl>
 
-## I
-
-<dl>
-  <dt>Infrastructure as a Service (IaaS)</dt>
-  <dd>A service that manages storage, servers, and networking resources for businesses through virtual machines. One of three main services, the other two are SaaS and PaaS.</dd>
-</dl>
-
 ## L
 <dl>
   <dt>Load Balancing </dt>


### PR DESCRIPTION
I deleted the definition of IaaS, which was listed twice.